### PR TITLE
Basic DuckDB support and test

### DIFF
--- a/Kull.DatabaseMetadata.Test/Kull.DatabaseMetadata.Test.csproj
+++ b/Kull.DatabaseMetadata.Test/Kull.DatabaseMetadata.Test.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6</TargetFrameworks>
+    <TargetFrameworks>net8;net6</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <IsPackable>false</IsPackable>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
+    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />

--- a/src/Kull.DatabaseMetadata/DBConnectionExtensions.cs
+++ b/src/Kull.DatabaseMetadata/DBConnectionExtensions.cs
@@ -5,7 +5,7 @@ using Kull.Data;
 
 namespace Kull.DatabaseMetadata;
 
-internal static class DBConnectionExtensions
+public static class DBConnectionExtensions
 {
     public static string GetParameterSqlChar(this DbConnection dbConnection) => IsDuckDB(dbConnection) ? "$" : "@";
     public static string GetParameterNameChar(this DbConnection dbConnection) => IsDuckDB(dbConnection) ? "" : "@";

--- a/src/Kull.DatabaseMetadata/DBConnectionExtensions.cs
+++ b/src/Kull.DatabaseMetadata/DBConnectionExtensions.cs
@@ -7,8 +7,35 @@ namespace Kull.DatabaseMetadata;
 
 internal static class DBConnectionExtensions
 {
+    public static string GetParameterSqlChar(this DbConnection dbConnection) => IsDuckDB(dbConnection) ? "$" : "@";
+    public static string GetParameterNameChar(this DbConnection dbConnection) => IsDuckDB(dbConnection) ? "" : "@";
+
+    public static bool IsDuckDB(this DbConnection dbConnection) => dbConnection.GetType().Name.Equals("DuckDBConnection", StringComparison.OrdinalIgnoreCase);
     public static bool IsSQLite(this DbConnection dbConnection) => dbConnection.GetType().Name.Equals("SqliteConnection", StringComparison.OrdinalIgnoreCase);
     public static bool IsMSSqlServer(this DbConnection dbConnection) =>
             dbConnection.GetType().FullName!.StartsWith("System.Data.SqlClient") || dbConnection.GetType().FullName!.StartsWith("Microsoft.Data.SqlClient");
+}
+
+internal static class CommandExtensions
+{
+
+    public static DbCommand FixParameterChars(this DbCommand cmd)
+    {
+        if (cmd.Parameters.Count == 0)
+        {
+            return cmd;
+        }
+        if (!cmd.Connection.IsDuckDB())
+        {
+            return cmd;
+        }
+        var text = cmd.CommandText;
+        foreach (DbParameter item in cmd.Parameters)
+        {
+            text = text.Replace("@" + item.ParameterName, "$" + item.ParameterName);
+        }
+        cmd.CommandText = text;
+        return cmd;
+    }
 }
 

--- a/src/Kull.DatabaseMetadata/Keys.cs
+++ b/src/Kull.DatabaseMetadata/Keys.cs
@@ -45,8 +45,9 @@ WHERE t.constraint_type='PRIMARY KEY'
         var cmd = con.CreateCommand();
         cmd.CommandText = sql;
         cmd.CommandType = System.Data.CommandType.Text;
-        cmd.AddCommandParameter("@Schema", tableName?.Schema);
-        cmd.AddCommandParameter("@TableName", tableName?.Name);
+        cmd.AddCommandParameter("Schema", tableName?.Schema);
+        cmd.AddCommandParameter("TableName", tableName?.Name);
+        cmd.FixParameterChars();
         using (var rdr = await cmd.ExecuteReaderAsync())
         {
             if (!rdr.HasRows) return Array.Empty<(DBObjectName Table, string columnName)>();

--- a/src/Kull.DatabaseMetadata/Kull.DatabaseMetadata.csproj
+++ b/src/Kull.DatabaseMetadata/Kull.DatabaseMetadata.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6;netstandard2.0;net48;netcoreapp3.1</TargetFrameworks>
-		<Version>1.6.2</Version>
+		<TargetFrameworks>net8;net6;netstandard2.0;net48</TargetFrameworks>
+		<Version>1.7.0</Version>
 		<PackageId>Kull.DatabaseMetadata</PackageId>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -32,7 +32,8 @@
 	</ItemGroup>
 	<ItemGroup Condition=" $(TargetFramework) != 'net48'">
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"
+			Version="2.1.1" />
 	</ItemGroup>
 	<ItemGroup Condition=" $(TargetFramework) == 'net48'">
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/Kull.DatabaseMetadata/SPParametersProvider.cs
+++ b/src/Kull.DatabaseMetadata/SPParametersProvider.cs
@@ -44,8 +44,9 @@ WHERE SPECIFIC_NAME = @SPName  AND SPECIFIC_SCHEMA=isnull(@Schema, schema_NAME()
         await con.AssureOpenAsync();
         DbCommand cmd = con.CreateCommand();
         cmd.CommandText = command;
-        cmd.AddCommandParameter("@SPName", storedProcedure.Name)
-            .AddCommandParameter("@Schema", storedProcedure.Schema);
+        cmd.AddCommandParameter("SPName", storedProcedure.Name)
+            .AddCommandParameter("Schema", storedProcedure.Schema);
+        cmd.FixParameterChars();
         List<SPParameter> resultL = new List<SPParameter>();
 
         using (var reader = await cmd.ExecuteReaderAsync())
@@ -62,11 +63,11 @@ WHERE SPECIFIC_NAME = @SPName  AND SPECIFIC_SCHEMA=isnull(@Schema, schema_NAME()
                         new DBObjectName(userDefinedSchema, userDefinedName) : null;
                     string parameterMode = reader.GetString(4);
                     System.Data.ParameterDirection? parameterDirection = parameterMode.Equals("IN", System.StringComparison.CurrentCultureIgnoreCase)
-                            ? System.Data.ParameterDirection.Input:
-                            parameterMode.Equals("OUT", System.StringComparison.CurrentCultureIgnoreCase) ? System.Data.ParameterDirection.Output:
+                            ? System.Data.ParameterDirection.Input :
+                            parameterMode.Equals("OUT", System.StringComparison.CurrentCultureIgnoreCase) ? System.Data.ParameterDirection.Output :
                             parameterMode.Equals("INOUT", System.StringComparison.CurrentCultureIgnoreCase) ? System.Data.ParameterDirection.InputOutput
-                            : (System.Data.ParameterDirection?) null;
-                    if(parameterDirection == null)
+                            : (System.Data.ParameterDirection?)null;
+                    if (parameterDirection == null)
                     {
                         logger.LogWarning($"Cannot parse Parameter mode {parameterMode} of {name} of {storedProcedure}");
                     }


### PR DESCRIPTION
- Drops support for out-of-support .net core 3.1
- Adds basic Support for DuckDB, at least for getting tables and columns